### PR TITLE
fix: Update handling of timeout errors in scraper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ bundle install # install the gems
 rake db:create # create the database
 rake db:migrate # create the colleges table
 rake # scrape the colleges and populate the database ✨
+
+# This script run can take many hours. If you're on a Mac, you may need to run the following command to prevent the computer from sleeping:
+caffeinate -i rake
 ```
 
 > ℹ️ **Info:** If you run into any issues with the script not running, make sure your postgres service is running. You can start it via homebrew with `brew services start postgresql`. Additionally, any scraping failures will be logged in `errors.log` and can be manually remediated following script run.

--- a/exec/college_crawler.rb
+++ b/exec/college_crawler.rb
@@ -178,7 +178,7 @@ class CollegeCrawler
     begin
       scrape_college_board_code(college_page_url)
     rescue Puppeteer::Connection::ProtocolError, Puppeteer::TimeoutError,
-           Puppeteer::LifecycleWatcher::TerminatedError => e
+           Puppeteer::LifecycleWatcher::TerminatedError, Timeout::Error => e
       retries += 1
       if retries <= max_retries
         sleep(2**retries)


### PR DESCRIPTION
Add Timeout::Error to the list of exceptions to handle when scraping college data. Add to readme on how to run w/o system sleep