### PR TITLE
feat(exec): Add resume functionality to college crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ rake db:create # create the database
 rake db:migrate # create the colleges table
 rake # scrape the colleges and populate the database ✨
 
+rake resume # resume a recent script run 🐢
+# Note: we have no guarantee that the source data set has not changed since the last run.
+
 # This script run can take many hours. If you're on a Mac, you may need to run the following command to prevent the computer from sleeping:
 caffeinate -i rake
+caffeinate -i rake resume # if resuming a previous run
 ```
 
 > ℹ️ **Info:** If you run into any issues with the script not running, make sure your postgres service is running. You can start it via homebrew with `brew services start postgresql`. Additionally, any scraping failures will be logged in `errors.log` and can be manually remediated following script run.
@@ -82,9 +86,14 @@ After setting up the project, may now execute the college crawler script to scra
 # runs the college scrape task ✨
 rake
 
+# resume a previous run 🐢
+rake resume
+# Note: we have no guarantee that the source data set has not changed since the last run.
+
 # Note: this script can take hours to run. You may wish to:
 # Runs the task and prevent system sleep 💊
 caffeinate -i rake
+caffeinate -i rake resume # if resuming
 ```
 
 This will take awhile to complete and will populate the database with college data.

--- a/Rakefile
+++ b/Rakefile
@@ -67,6 +67,17 @@ task :scrape do
   CollegeCrawler.new.run
 end
 
+# Warning: use with caution. We have no guarantee that the data set has not
+# changed from the College Board server since the last run. If you are resuming
+# a recent failure, it's likely that the data has not changed in such short
+# duration. If the failure is older, you should restart the scrape from scratch.
+desc 'Resume a recent run of the college crawler'
+task :resume do
+  require_relative './exec/college_crawler'
+
+  CollegeCrawler.new(resume_mode: true).run
+end
+
 desc 'Run RSpec tests'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/**/*_spec.rb'

--- a/exec/college_crawler.rb
+++ b/exec/college_crawler.rb
@@ -23,6 +23,9 @@ require_relative '../models/college'
 #   the college's webpage.
 # - Inserts the processed data into the database.
 #
+# Optional Parameters:
+#   - resume_mode: If true, the script will resume from the last saved index.
+#
 # Usage:
 #   CollegeCrawler.new.run
 #
@@ -39,9 +42,10 @@ class CollegeCrawler
   COLLEGE_PAGE_BASE_URL = 'https://bigfuture.collegeboard.org/colleges'
   FILTER_PAGE_URL = 'https://bigfuture.collegeboard.org/college-search/filters'
 
-  def initialize
+  def initialize(resume_mode: false)
     @batch_size = 50
     @logger = LoggingConfig.setup
+    @resume_mode = resume_mode
   end
 
   def run
@@ -60,8 +64,19 @@ class CollegeCrawler
 
   private
 
+  def initial_index
+    # Resume mode picks up from the last existing index
+    last_index = [College.order(:id).count - 1, 0].max
+    @resume_mode ? last_index : 0
+  end
+
+  def subsequent_index
+    last_index = [College.order(:id).count - 1, 0].max
+    @resume_mode ? last_index + @batch_size : @batch_size
+  end
+
   def fetch_initial_colleges
-    from = 0
+    from = initial_index
     response = fetch_college_batch(from)
 
     total_hits = response['totalHits']
@@ -74,12 +89,15 @@ class CollegeCrawler
     puts "✨ Let's steal some data! 💸"
     puts "🥷 Colleges at #{FILTER_PAGE_URL} will be scraped..."
     puts "🔍 Total colleges found: #{total_hits}"
+    puts "🐢 Resuming from #{initial_index + 1}/#{total_hits}..." if @resume_mode
     puts '🌀 Processing...'
   end
 
   def display_progress_bar(total_hits)
+    current_count = @resume_mode ? College.count : 0
     ProgressBar.create(
       total: total_hits,
+      starting_at: current_count,
       format: '%a |%b%i| %p%% %t | %c/%C | %e',
       progress_mark: '█',
       remainder_mark: '░'
@@ -87,7 +105,7 @@ class CollegeCrawler
   end
 
   def fetch_and_process_remaining_colleges(total_hits, progress_bar)
-    from = @batch_size
+    from = subsequent_index
     while from < total_hits
       colleges = fetch_college_batch(from)['data']
       process_colleges(colleges, progress_bar)


### PR DESCRIPTION
**WIP**
- Add the ability to resume a previous run with the resume_mode parameter set to true. 
- This will allow the script to pick up from the last saved index and continue scraping. Note of caution is included in README. A more robust solution is documented in readme [Improvements](https://github.com/twknab/sei?tab=readme-ov-file#%EF%B8%8F-improvements) section

Note: this was working for in testing, but I seemed to get some unexpected behavior with the "resume pointer" and need to investigate/think more about this. The feature *does technically work*, but sometimes can be 1 batch size "behind" (so the first batch writes get skipped), and will "resume" on second iteration. Would love to dial this feature in and understand the deeper issue.